### PR TITLE
Implement automatic package.json path overwriting functionality

### DIFF
--- a/Editor/PackageImporter.cs
+++ b/Editor/PackageImporter.cs
@@ -59,6 +59,8 @@ namespace Artees.UnityPackageManifestGenerator.Editor
         private PackageAuthor author = new PackageAuthor();
 
         [SerializeField, HideInInspector] private bool autoExportJson = true;
+        [SerializeField, HideInInspector] private bool overrideExportJsonPath = false;
+        [SerializeField, HideInInspector] private string exportJsonPath = string.Empty;
 
         [SerializeField, HideInInspector] private string registryUrl = "https://registry.my-company.com";
 #pragma warning restore 649
@@ -69,6 +71,22 @@ namespace Artees.UnityPackageManifestGenerator.Editor
         {
             get => autoExportJson;
             set => autoExportJson = value;
+        }
+
+        [SuppressMessage("ReSharper", "ConvertToAutoProperty",
+            Justification = "Serialized backing field")]
+        public bool OverrideExportJsonPath
+        {
+            get => overrideExportJsonPath;
+            set => overrideExportJsonPath = value;
+        }
+
+        [SuppressMessage("ReSharper", "ConvertToAutoProperty",
+            Justification = "Serialized backing field")]
+        public string AutoExportJsonPath
+        {
+            get => exportJsonPath;
+            set => exportJsonPath = value;
         }
 
         [SuppressMessage("ReSharper", "ConvertToAutoProperty",

--- a/Editor/PackageImporterEditor.cs
+++ b/Editor/PackageImporterEditor.cs
@@ -61,6 +61,7 @@ namespace Artees.UnityPackageManifestGenerator.Editor
             GUI.SetNextControlName(FirstControlName);
             base.OnInspectorGUI();
             CreateImportExportGui();
+            if (Target.AutoExportJson) CreateOverrideExportPathGui();
             CreatePublishGui();
             CreateAsmdefWarning();
         }
@@ -74,6 +75,21 @@ namespace Artees.UnityPackageManifestGenerator.Editor
             Target.AutoExportJson = GUILayout.Toggle(Target.AutoExportJson, autoExportContent);
             if (CreateButton("Import package.json...", "Import the package manifest file")) ImportJson();
             if (CreateButton("Export package.json...", "Export the package manifest file")) ExportJsonAs();
+            GUILayout.EndHorizontal();
+        }
+
+        private void CreateOverrideExportPathGui()
+        {
+            GUILayout.BeginHorizontal();
+            var autoExportPathContent = new GUIContent("Override Auto Export Path",
+                "Where do you save the package manifest file (package.json)?");
+            Target.OverrideExportJsonPath = GUILayout.Toggle(Target.OverrideExportJsonPath, autoExportPathContent);
+            if (Target.OverrideExportJsonPath)
+            {
+                GUILayout.EndHorizontal();
+                GUILayout.BeginHorizontal();
+                Target.AutoExportJsonPath = GUILayout.TextField(Target.AutoExportJsonPath);
+            }
             GUILayout.EndHorizontal();
         }
 
@@ -121,6 +137,12 @@ namespace Artees.UnityPackageManifestGenerator.Editor
             get
             {
                 var assetPath = AssetDatabase.GetAssetPath(target);
+                if (Target.OverrideExportJsonPath)
+                {
+                    var dirName = Path.GetDirectoryName(assetPath);
+                    var fileName = Path.GetFileName(assetPath);
+                    assetPath = Path.Combine(dirName, Target.AutoExportJsonPath, fileName);
+                }
                 var relativeJsonPath = Path.ChangeExtension(assetPath, JsonExtension);
                 if (string.IsNullOrEmpty(relativeJsonPath))
                 {


### PR DESCRIPTION
This commit introduces a new feature that allows users to automatically override the package.json path.

With this feature, users can specify a flag that will cause the script to automatically overwrite the default auto export path with the provided value. This will save time and effort, as it will eliminate the need to manually move the package.json file everytime.

![2024051475-NjnJTSH4Bm](https://github.com/Artees/Unity-Package-Manifest-Generator/assets/10691716/67d7de67-2411-4522-9416-e356486ed11d)
